### PR TITLE
Laravel 5.4 compatibility

### DIFF
--- a/src/Middleware/Reauthenticate.php
+++ b/src/Middleware/Reauthenticate.php
@@ -20,7 +20,7 @@ class Reauthenticate
         $reauth = new ReauthLimiter($request);
 
         if (!$reauth->check()) {
-            $request->session()->set('url.intended', $request->url());
+            $request->session()->put('url.intended', $request->url());
 
             return $this->invalidated($request);
         }

--- a/src/ReauthLimiter.php
+++ b/src/ReauthLimiter.php
@@ -55,8 +55,8 @@ class ReauthLimiter
             return false;
         }
 
-        $this->request->session()->set($this->key.'.life', Carbon::now()->timestamp);
-        $this->request->session()->set($this->key.'.authenticated', true);
+        $this->request->session()->put($this->key.'.life', Carbon::now()->timestamp);
+        $this->request->session()->put($this->key.'.authenticated', true);
 
         return true;
     }

--- a/tests/ReauthenticateControllerTest.php
+++ b/tests/ReauthenticateControllerTest.php
@@ -21,7 +21,7 @@ class ReauthenticateControllerTest extends Orchestra\Testbench\TestCase
         $request = \Illuminate\Http\Request::create('http://reauthenticate.app/auth/reauthenticate', 'POST', [
             'password' => 'test',
         ]);
-        $request->setSession(app('session.store'));
+        $request->setLaravelSession(app('session.store'));
 
         $controller = new TestController();
 
@@ -44,7 +44,7 @@ class ReauthenticateControllerTest extends Orchestra\Testbench\TestCase
         $request = \Illuminate\Http\Request::create('http://reauthenticate.app/auth/reauthenticate', 'POST', [
             'password' => 'test',
         ]);
-        $request->setSession(app('session.store'));
+        $request->setLaravelSession(app('session.store'));
 
         $controller = new TestController();
 

--- a/tests/ReauthenticateControllerTest.php
+++ b/tests/ReauthenticateControllerTest.php
@@ -21,7 +21,7 @@ class ReauthenticateControllerTest extends Orchestra\Testbench\TestCase
         $request = \Illuminate\Http\Request::create('http://reauthenticate.app/auth/reauthenticate', 'POST', [
             'password' => 'test',
         ]);
-        $request->setLaravelSession(app('session.store'));
+        $this->setSession($request, app('session.store'));
 
         $controller = new TestController();
 
@@ -44,7 +44,7 @@ class ReauthenticateControllerTest extends Orchestra\Testbench\TestCase
         $request = \Illuminate\Http\Request::create('http://reauthenticate.app/auth/reauthenticate', 'POST', [
             'password' => 'test',
         ]);
-        $request->setLaravelSession(app('session.store'));
+        $this->setSession($request, app('session.store'));
 
         $controller = new TestController();
 
@@ -70,6 +70,23 @@ class ReauthenticateControllerTest extends Orchestra\Testbench\TestCase
         // Setup default database to use sqlite :memory:
         $app['config']->set('session.driver', 'array');
         $app['config']->set('auth.model', 'TestUser');
+    }
+
+    /**
+     * Set the session for tests in a backwards compatible way
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param Illuminate\Session\Store $session
+     *
+     * @return void
+     */
+    protected function setSession($request, $session)
+    {
+        if (method_exists($request, 'setLaravelSession')) {
+            return $request->setLaravelSession($session);
+        }
+
+        return $request->setSession($session);
     }
 }
 

--- a/tests/ReauthenticateControllerTest.php
+++ b/tests/ReauthenticateControllerTest.php
@@ -40,7 +40,7 @@ class ReauthenticateControllerTest extends Orchestra\Testbench\TestCase
             ->once()
             ->andReturn($user);
 
-        Session::set('url.intended', 'http://reauthenticate.app/auth/reauthenticate');
+        Session::put('url.intended', 'http://reauthenticate.app/auth/reauthenticate');
         $request = \Illuminate\Http\Request::create('http://reauthenticate.app/auth/reauthenticate', 'POST', [
             'password' => 'test',
         ]);

--- a/tests/ReauthenticateTest.php
+++ b/tests/ReauthenticateTest.php
@@ -12,7 +12,7 @@ class ReauthenticateTest extends Orchestra\Testbench\TestCase
         $request = \Illuminate\Http\Request::create('http://reauthenticate.app/restricted', 'GET', [
             'password' => 'test',
         ]);
-        $request->setSession(app('session.store'));
+        $request->setLaravelSession(app('session.store'));
 
         /** @var Illuminate\Http\RedirectResponse $result */
         $result = $middleware->handle($request, $closure);
@@ -37,7 +37,7 @@ class ReauthenticateTest extends Orchestra\Testbench\TestCase
         $request = \Illuminate\Http\Request::create('http://reauthenticate.app/restricted', 'GET', [
             'password' => 'test',
         ]);
-        $request->setSession(app('session.store'));
+        $request->setLaravelSession(app('session.store'));
 
         /** @var Illuminate\Http\RedirectResponse $result */
         $result = $middleware->handle($request, $closure);
@@ -59,7 +59,7 @@ class ReauthenticateTest extends Orchestra\Testbench\TestCase
         $request = \Illuminate\Http\Request::create('http://reauthenticate.app/restricted', 'GET', [
             'password' => 'test',
         ]);
-        $request->setSession(app('session.store'));
+        $request->setLaravelSession(app('session.store'));
 
         /** @var Illuminate\Http\RedirectResponse $result */
         $result = $middleware->handle($request, $closure);

--- a/tests/ReauthenticateTest.php
+++ b/tests/ReauthenticateTest.php
@@ -23,8 +23,8 @@ class ReauthenticateTest extends Orchestra\Testbench\TestCase
 
     public function test_middleware_returns_next_with_valid_data()
     {
-        \Session::set('reauthenticate.life', \Carbon\Carbon::now()->timestamp);
-        \Session::set('reauthenticate.authenticated', true);
+        \Session::put('reauthenticate.life', \Carbon\Carbon::now()->timestamp);
+        \Session::put('reauthenticate.authenticated', true);
 
         $middleware = new \Mpociot\Reauthenticate\Middleware\Reauthenticate();
 
@@ -48,8 +48,8 @@ class ReauthenticateTest extends Orchestra\Testbench\TestCase
 
     public function test_middleware_returns_redirect_with_invalid_data()
     {
-        \Session::set('reauthenticate.life', \Carbon\Carbon::minValue()->timestamp);
-        \Session::set('reauthenticate.authenticated', true);
+        \Session::put('reauthenticate.life', \Carbon\Carbon::minValue()->timestamp);
+        \Session::put('reauthenticate.authenticated', true);
 
         $middleware = new \Mpociot\Reauthenticate\Middleware\Reauthenticate();
         $closure = function () {

--- a/tests/ReauthenticateTest.php
+++ b/tests/ReauthenticateTest.php
@@ -12,7 +12,7 @@ class ReauthenticateTest extends Orchestra\Testbench\TestCase
         $request = \Illuminate\Http\Request::create('http://reauthenticate.app/restricted', 'GET', [
             'password' => 'test',
         ]);
-        $request->setLaravelSession(app('session.store'));
+        $this->setSession($request, app('session.store'));
 
         /** @var Illuminate\Http\RedirectResponse $result */
         $result = $middleware->handle($request, $closure);
@@ -37,7 +37,7 @@ class ReauthenticateTest extends Orchestra\Testbench\TestCase
         $request = \Illuminate\Http\Request::create('http://reauthenticate.app/restricted', 'GET', [
             'password' => 'test',
         ]);
-        $request->setLaravelSession(app('session.store'));
+        $this->setSession($request, app('session.store'));
 
         /** @var Illuminate\Http\RedirectResponse $result */
         $result = $middleware->handle($request, $closure);
@@ -59,7 +59,7 @@ class ReauthenticateTest extends Orchestra\Testbench\TestCase
         $request = \Illuminate\Http\Request::create('http://reauthenticate.app/restricted', 'GET', [
             'password' => 'test',
         ]);
-        $request->setLaravelSession(app('session.store'));
+        $this->setSession($request, app('session.store'));
 
         /** @var Illuminate\Http\RedirectResponse $result */
         $result = $middleware->handle($request, $closure);
@@ -79,5 +79,22 @@ class ReauthenticateTest extends Orchestra\Testbench\TestCase
     {
         // Setup default database to use sqlite :memory:
         $app['config']->set('session.driver', 'array');
+    }
+
+    /**
+     * Set the session for tests in a backwards compatible way
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param Illuminate\Session\Store $session
+     *
+     * @return void
+     */
+    protected function setSession($request, $session)
+    {
+        if (method_exists($request, 'setLaravelSession')) {
+            return $request->setLaravelSession($session);
+        }
+
+        return $request->setSession($session);
     }
 }


### PR DESCRIPTION
Laravel 5.4 removed the `Session::set()` method as it was not intended for public use. This PR replaces the calls to `Session::set()` with calls to `Session::put()` to restore compatibility with current versions of Laravel.