### PR TITLE
Add ability to customize redirect url

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,16 @@ Route::post('auth/reauthenticate', 'Auth\AuthController@postReauthenticate');
 That's it.
 Once the user successfully reauthenticates, the valid login will be stored for 30 minutes.
 
-This value can be configured by extending the Reauthenticate middleware.
+The URL the user gets redirected to can be configured by adding a `reauthenticate_url` key
+to your `config/app.php` file:
+
+```php
+return [
+    // ...
+
+    'reauthenticate_url' => '/custom-url',
+];
+```
 
 <a name="license" />
 ## License

--- a/src/Middleware/Reauthenticate.php
+++ b/src/Middleware/Reauthenticate.php
@@ -22,7 +22,7 @@ class Reauthenticate
         if (!$reauth->check()) {
             $request->session()->put('url.intended', $request->url());
 
-            return $this->invalidated();
+            return $this->invalidated($request);
         }
 
         return $next($request);
@@ -31,9 +31,11 @@ class Reauthenticate
     /**
      * Handle invalidated auth.
      *
+     * @param \Illuminate\Http\Request
+     *
      * @return \Illuminate\Http\RedirectResponse
      */
-    protected function invalidated()
+    protected function invalidated($request)
     {
         $url = config('app.reauthenticate_url', 'auth/reauthenticate');
 

--- a/src/Middleware/Reauthenticate.php
+++ b/src/Middleware/Reauthenticate.php
@@ -22,7 +22,7 @@ class Reauthenticate
         if (!$reauth->check()) {
             $request->session()->put('url.intended', $request->url());
 
-            return $this->invalidated($request);
+            return $this->invalidated();
         }
 
         return $next($request);
@@ -31,12 +31,12 @@ class Reauthenticate
     /**
      * Handle invalidated auth.
      *
-     * @param \Illuminate\Http\Request $request
-     *
-     * @return mixed
+     * @return \Illuminate\Http\RedirectResponse
      */
-    protected function invalidated($request)
+    protected function invalidated()
     {
-        return redirect('auth/reauthenticate');
+        $url = config('app.reauthenticate_url', 'auth/reauthenticate');
+
+        return redirect($url);
     }
 }

--- a/tests/ReauthenticateTest.php
+++ b/tests/ReauthenticateTest.php
@@ -68,6 +68,25 @@ class ReauthenticateTest extends Orchestra\Testbench\TestCase
         $this->assertEquals(\Session::get('url.intended'), 'http://reauthenticate.app/restricted');
     }
 
+    public function test_middleware_returns_customized_redirect_url()
+    {
+        $middleware = new \Mpociot\Reauthenticate\Middleware\Reauthenticate();
+        $closure = function () {
+        };
+
+        /** @var Illuminate\Http\Request $request */
+        $request = \Illuminate\Http\Request::create('http://reauthenticate.app/restricted', 'GET', [
+            'password' => 'test',
+        ]);
+        $this->setSession($request, app('session.store'));
+
+        config()->set('app.reauthenticate_url', '/custom-url');
+
+        /** @var Illuminate\Http\RedirectResponse $result */
+        $result = $middleware->handle($request, $closure);
+        $this->assertEquals('http://localhost/custom-url', $result->getTargetUrl());
+    }
+
     /**
      * Define environment setup.
      *


### PR DESCRIPTION
Instead of this package providing its own service provider, we can let the user add a key to `config/app.php` if they want to 🙂 

It'll default to `'auth/reauthenticate'`, so backwards compatibility is kept.