### PR TITLE
Update README and allow more configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,29 +65,23 @@ The HTTP controller methods can be used from the `Reauthenticates` trait, so you
 
 namespace App\Http\Controllers\Auth;
 
-use App\User;
-use Validator;
 use App\Http\Controllers\Controller;
 use Mpociot\Reauthenticate\Reauthenticates;
-use Illuminate\Foundation\Auth\ThrottlesLogins;
-use Illuminate\Foundation\Auth\AuthenticatesAndRegistersUsers;
+use Illuminate\Foundation\Auth\AuthenticatesUsers;
 
-class AuthController extends Controller
+class LoginController extends Controller
 {
     /*
     |--------------------------------------------------------------------------
-    | Registration & Login Controller
+    | Login Controller
     |--------------------------------------------------------------------------
     |
-    | This controller handles the registration of new users, as well as the
-    | authentication of existing users. By default, this controller uses
-    | a simple trait to add these behaviors. Why don't you explore it?
+    | This controller handles authenticating users for the application and
+    | redirecting them to your home screen. The controller uses a trait
+    | to conveniently provide its functionality to your applications.
     |
     */
-
-    use AuthenticatesAndRegistersUsers, ThrottlesLogins, Reauthenticates {
-        AuthenticatesAndRegistersUsers::getFailedLoginMessage insteadof Reauthenticates;
-    }
+    use AuthenticatesUsers, Reauthenticates;
 ```
 
 Be sure to except the reauthenticate routes from the `guest` middleware.
@@ -108,8 +102,10 @@ To get started, add these routes to your `routes.php` file:
 
 ```php
 // Reauthentication routes
-Route::get('auth/reauthenticate', 'Auth\AuthController@getReauthenticate');
-Route::post('auth/reauthenticate', 'Auth\AuthController@postReauthenticate');
+Route::namespace('Auth')->group(function () {
+    Route::get('auth/reauthenticate', 'LoginController@getReauthenticate');
+    Route::post('auth/reauthenticate', 'LoginController@postReauthenticate');
+});
 ```
 
 That's it.

--- a/README.md
+++ b/README.md
@@ -109,16 +109,36 @@ Route::namespace('Auth')->group(function () {
 ```
 
 That's it.
-Once the user successfully reauthenticates, the valid login will be stored for 30 minutes.
 
-The URL the user gets redirected to can be configured by adding a `reauthenticate_url` key
-to your `config/app.php` file:
+Once the user successfully reauthenticates, the valid login will be stored for 30 minutes by default.
+
+## Optional Configuration
+
+Reauthenticate can be (optionally) configured through your `config/app.php` file. The following keys are supported:
 
 ```php
 return [
-    // ...
-
+    /*
+    |--------------------------------------------------------------------------
+    | Reauthenticate
+    |--------------------------------------------------------------------------
+    */
+    
+    /**
+     * The URL to redirect to after re-authentication is successful.
+     */
     'reauthenticate_url' => '/custom-url',
+
+    /**
+     * The key to use as your re-authentication session key.
+     */
+    'reauthenticate_key' => 'custom-reauthentication-key',
+
+    /**
+     * The time (in minutes) that the user is allowed to access the protected area 
+     * before being prompted to re re-authenticate.
+     */
+    'reauthenticate_time' => 30,
 ];
 ```
 

--- a/src/ReauthLimiter.php
+++ b/src/ReauthLimiter.php
@@ -39,8 +39,8 @@ class ReauthLimiter
     public function __construct(Request $request, $key = null, $reauthTime = null)
     {
         $this->request = $request;
-        $this->key = $key ?? $this->key;
-        $this->reauthTime = $reauthTime ?? $this->reauthTime;
+        $this->key = $key ?: $this->key;
+        $this->reauthTime = $reauthTime ?: $this->reauthTime;
     }
 
     /**

--- a/src/ReauthLimiter.php
+++ b/src/ReauthLimiter.php
@@ -36,10 +36,11 @@ class ReauthLimiter
      * @param \Illuminate\Http\Request $request
      * @param string                   $key
      */
-    public function __construct(Request $request, $key = null)
+    public function __construct(Request $request, $key = null, $reauthTime = null)
     {
         $this->request = $request;
-        $this->key = $key ?: $this->key;
+        $this->key = $key ?? $this->key;
+        $this->reauthTime = $reauthTime ?? $this->reauthTime;
     }
 
     /**

--- a/src/Reauthenticates.php
+++ b/src/Reauthenticates.php
@@ -30,7 +30,9 @@ trait Reauthenticates
             'password' => 'required',
         ]);
 
-        $reauth = new ReauthLimiter($request);
+        $reauthKey = config('app.reauthenticate_key') ?? null;
+        $reauthTime = config('app.reauthenticate_time') ?? null;
+        $reauth = new ReauthLimiter($request, $reauthKey, $reauthTime);
 
         if (!$reauth->attempt($request->password)) {
             return Redirect::back()

--- a/src/Reauthenticates.php
+++ b/src/Reauthenticates.php
@@ -30,8 +30,8 @@ trait Reauthenticates
             'password' => 'required',
         ]);
 
-        $reauthKey = config('app.reauthenticate_key') ?? null;
-        $reauthTime = config('app.reauthenticate_time') ?? null;
+        $reauthKey = config('app.reauthenticate_key') ?: null;
+        $reauthTime = config('app.reauthenticate_time') ?: null;
         $reauth = new ReauthLimiter($request, $reauthKey, $reauthTime);
 
         if (!$reauth->attempt($request->password)) {


### PR DESCRIPTION
The current README mentions an AuthController, but I do not have one of these. I have the following controllers: https://github.com/laravel/laravel/tree/master/app/Http/Controllers/Auth

`LoginController`, `RegisterController`, `ForgotPasswordController` and `ResetPasswordController`

So I've updated the README.md to reflect changes to the default Laravel authentication structure.

Tested locally with this implementation, working fine here. Only thing I couldn't find implemented was the `getFailedLoginMessage` method you were overriding with your `use` statement, I believe this has now changed to `sendFailedLoginResponse` in `Illuminate\Foundation\Auth\AuthenticatesUsers`

Hope it's okay!