### PR TITLE
Abandon the package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,6 @@
         }
     },
     "prefer-stable": true,
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "abandoned": true
 }


### PR DESCRIPTION
Starting from Laravel 6, the framework ships with a built-in `Illuminate\Auth\Middleware\RequirePassword` middleware aliased as `password.confirm` that does the same job. 

https://laravel.com/docs/authentication#password-confirmation
